### PR TITLE
Revert "Prevent  repo2docker step in CI from timing out for 15 mins"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,7 +45,6 @@ jobs:
         echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
     - name: Running repo2docker
-      timeout-minutes: 900
       run: |
         if docker pull "${IMAGE_NAME}"; then
           echo "Using ${IMAGE_NAME} as cache"


### PR DESCRIPTION
Reverts alan-turing-institute/bridge-data-environment#3

Why #3  PR didn't work:

- The flag is `timeout-minutes` and I mistakenly thought it was seconds so the previous PR actually bumped the timeout limit to 900 _minutes_
- The default timeout is 360 minutes (6 hours) so it can't be GitHub cancelling the job that's causing the timeout problem.

https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes