### PR TITLE
Modifications

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,3 +1,5 @@
+jupyterhub==0.9.2
 matplotlib
 numpy
+pip>=20.0.2
 scipy

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,13 +46,7 @@ jobs:
 
     - name: Running repo2docker
       run: |
-        if docker pull "${IMAGE_NAME}"; then
-          echo "Using ${IMAGE_NAME} as cache"
-          jupyter-repo2docker --image-name "${IMAGE_NAME}" --debug --no-run --push --user-id 1000 --user-name jovyan --cache-from "${IMAGE_NAME}" "${DIR_TO_BUILD}"
-        else
-          echo "Building ${IMAGE_NAME} from scratch"
-          jupyter-repo2docker --image-name "${IMAGE_NAME}" --debug --no-run --push --user-id 1000 --user-name jovyan "${DIR_TO_BUILD}"
-        fi
+        jupyter-repo2docker --image-name "${IMAGE_NAME}" --debug --no-run --push --user-id 1000 --user-name jovyan "${DIR_TO_BUILD}"
 
     - name: Tag and push image to Docker Hub
       run: |


### PR DESCRIPTION
- Pin JupyterHub version in `requirements.txt` to match our Hub deployed from https://github.com/alan-turing-institute/bridge-data-platform. This will make sure that the image will work on the Hub.
- Make sure we get an up-to-date version of `pip` too.
- Remove cache option from master build GitHub Action. Not sure it was working correctly.