### PR TITLE
:construction_worker: Add workflow to check notebooks for clean metadata

### DIFF
--- a/.github/workflows/clean-notebook-metadata.yml
+++ b/.github/workflows/clean-notebook-metadata.yml
@@ -1,0 +1,17 @@
+name: Ensure Clean Notebook Metadata
+
+on:
+  push:
+    paths:
+      - '.tests/**'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clean-notebooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check Notebooks for clean metadata
+        uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->

### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR adds a GitHub Action workflow that will fail if the metadata of any Jupyter Notebooks committed to the repo is not clean

### List of changes proposed in this PR

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
